### PR TITLE
Fix consent toggle handling

### DIFF
--- a/software/gesture-tracking/processing/PerceptualDrift_Tracker/PerceptualDrift_Tracker.pde
+++ b/software/gesture-tracking/processing/PerceptualDrift_Tracker/PerceptualDrift_Tracker.pde
@@ -76,10 +76,6 @@ void draw(){
   yaw = constrain(lat*0.2, -1, 1);
   crowd = constrain(motionCount / float(pixels.length) * 5.0, 0, 1);
 
-  // consent toggle — space bar flips on/off.  Consider mapping this to a foot
-  // switch or physical button in the gallery so the facilitator controls arming.
-  if (keyPressed && key==' ') consent = !consent;
-
   sendOSC("/pd/lat", lat);
   sendOSC("/pd/alt", alt);
   sendOSC("/pd/yaw", yaw);
@@ -94,6 +90,13 @@ void draw(){
   text(String.format("lat %.2f alt %.2f yaw %.2f crowd %.2f consent %s", lat, alt, yaw, crowd, consent), 10, 20);
 
   prev.copy(cam, 0,0, cam.width, cam.height, 0,0, width, height);
+}
+
+// consent toggle — space bar flips on/off.  Consider mapping this to a foot
+// switch or physical button in the gallery so the facilitator controls arming.
+// If you need to remap the arming key, this is the block to edit.
+void keyReleased(){
+  if (key == ' ') consent = !consent;
 }
 
 void sendOSC(String addr, float v){


### PR DESCRIPTION
## Summary
- move the consent toggle logic out of `draw()` and into a `keyReleased()` handler
- document where to remap the arming control for facilitators

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd893e32cc8325a96df0d6702c67b9