### PR TITLE
Hook OSC inputs into CrazySwarm services

### DIFF
--- a/software/swarm/README.md
+++ b/software/swarm/README.md
@@ -2,9 +2,50 @@
 
 This folder scaffolds integration with **CrazySwarm2** for multi-drone coordination.
 
-- **Use case**: >4 drones, semi-autonomous waypoint flights.
-- **Stack**: ROS2 Foxy/Humble + `crazyflie_firmware` + `crazyflie_ros`.
-- **Scripts**:
-  - `swarm_demo.py`: Example 3-drone pattern, driven by OSC crowd inputs.
+This is the place where Perceptual Drift's squishy human gestures become tight,
+punky drone choreography. The `swarm_demo.py` script listens to OSC messages and
+pushes them straight into CrazySwarm2 services.
 
-See: https://github.com/IMRCLab/crazyswarm2
+## Prerequisites
+
+| What | Why it matters |
+| ---- | -------------- |
+| ROS 2 Foxy or Humble workspace | `swarm_demo.py` is a ROS 2 node; source your workspace before launching. |
+| [`crazyflie_ros2`](https://github.com/IMRCLab/crazyswarm2) built in that workspace | Provides the `crazyflie_interfaces/srv/Takeoff` and `.../GoTo` services. |
+| Motion capture or Lighthouse tracking dialed in | CrazySwarm2 assumes you know where every drone lives. |
+| [`python-osc`](https://pypi.org/project/python-osc/) | Feeds the crowd-control data into ROS. |
+| Fully charged Crazyflies & a big enough safety net | We're commanding flight. Don't be reckless. |
+
+## Run it live
+
+1. Fire up your CrazySwarm2 stack (mocap, radio, etc.) and verify a single
+   drone responds to `ros2 service call /cf1/takeoff` in a safe, empty space.
+2. Copy `software/swarm/swarm_demo.py` into your ROS workspace or invoke it via
+   `ros2 run perceptual_drift_swarm swarm_demo` if you have it installed as a
+   package.
+3. Edit the tweakables at the top of the file: service names, axis choice,
+   scaling factors. Treat them like guard rails, not suggestions.
+4. In one terminal (with your workspace sourced):
+
+   ```bash
+   ros2 run perceptual_drift_swarm swarm_demo
+   ```
+
+   or, if you're just executing the script directly:
+
+   ```bash
+   python3 software/swarm/swarm_demo.py
+   ```
+
+5. Point Perceptual Drift's OSC output at the IP/port you configured (defaults
+   to `0.0.0.0:9010`).
+6. Flap your limbs. `/pd/alt` drives `Takeoff` height, `/pd/lat` slides the
+   craft laterally. Keep a thumb on the emergency stop.
+
+## Safety riffs
+
+* Never test in a crowd. Even punk shows have barricades.
+* Stay under local legal altitude limits and respect RF rules.
+* Keep the room soft: nets, curtains, no fragile art pieces.
+* Have a spotter ready to yank power the second a drone misbehaves.
+* Log everything. When things go weird (they will), you'll want receipts.

--- a/software/swarm/swarm_demo.py
+++ b/software/swarm/swarm_demo.py
@@ -14,10 +14,45 @@ installed.  Recommended reading:
 * ROS 2 services overview — https://docs.ros.org/en/humble/Concepts/Services.html
 """
 
+import math
+import threading
+from typing import Iterable, Optional
+
 import rclpy
 from rclpy.node import Node
 from pythonosc import dispatcher, osc_server
 from crazyflie_interfaces.srv import Takeoff, GoTo
+
+# ---------------------------------------------------------------------------
+# Tweakables — change these to match your swarm layout or taste.
+# ---------------------------------------------------------------------------
+
+# OSC server binding — Perceptual Drift publishes to this IP/port combo.
+OSC_BIND_ADDRESS = "0.0.0.0"
+OSC_BIND_PORT = 9010
+
+# ROS 2 service names exposed by crazyflie_ros2.
+GO_TO_SERVICE = "/cf1/go_to"
+TAKEOFF_SERVICE = "/cf1/takeoff"
+
+# Lateral motion scaling: incoming [-1, 1] values become X/Y offsets in meters.
+LATERAL_INPUT_RANGE = (-1.0, 1.0)
+LATERAL_HOME_M = 0.0
+LATERAL_SCALE_M = 0.7
+LATERAL_AXIS = "y"  # choose "x" or "y" depending on your room orientation
+
+# Altitude: convert normalized inputs into safe takeoff heights (meters).
+ALTITUDE_INPUT_RANGE = (0.0, 1.0)
+ALTITUDE_FLOOR_M = 0.3
+ALTITUDE_SCALE_M = 0.9
+
+# Motion timing and default metadata.  Set RELATIVE_MOVES to True if your GoTo
+# service expects relative offsets instead of absolute coordinates.
+GO_TO_DURATION_S = 0.5
+TAKEOFF_DURATION_S = 1.5
+GROUP_MASK = 0
+RELATIVE_MOVES = False
+
 
 
 class SwarmNode(Node):
@@ -32,8 +67,11 @@ class SwarmNode(Node):
 
         # CrazySwarm2 exposes one service per drone.  ``/cf1/go_to`` moves CF #1.
         # See ``ros2 service list`` for the services available in your workspace.
-        self.go_to = self.create_client(GoTo, "/cf1/go_to")
-        self.takeoff = self.create_client(Takeoff, "/cf1/takeoff")
+        self.go_to = self.create_client(GoTo, GO_TO_SERVICE)
+        self.takeoff = self.create_client(Takeoff, TAKEOFF_SERVICE)
+
+        self._current_altitude = ALTITUDE_FLOOR_M
+        self._current_lateral = LATERAL_HOME_M
 
         # Placeholder: bolt OSC handlers onto this dispatcher.
         self.dispatcher = dispatcher.Dispatcher()
@@ -41,20 +79,139 @@ class SwarmNode(Node):
         self.dispatcher.map("/pd/alt", self.on_alt)
 
         # Fire up a background OSC server.  Threading server keeps ROS spinning.
-        self.server = osc_server.ThreadingOSCUDPServer(("0.0.0.0", 9010), self.dispatcher)
+        self.server = osc_server.ThreadingOSCUDPServer((OSC_BIND_ADDRESS, OSC_BIND_PORT), self.dispatcher)
+        self._osc_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self._osc_thread.start()
         self.get_logger().info("OSC listening on %s:%d", *self.server.server_address)
 
     # ------------------------------------------------------------------
-    # OSC handlers — currently just log the incoming values.  Replace the
-    # TODOs with calls to ``self.go_to.call_async`` to actually move drones.
+    # OSC handlers — translate crowd gestures into CrazySwarm2 service calls.
     # ------------------------------------------------------------------
     def on_lat(self, addr, *vals):
-        self.get_logger().info("Received lateral input: %.3f", float(vals[0]))
-        # TODO: translate into GoTo requests with x/y offsets.
+        value = self._extract_first_value(vals)
+        if value is None:
+            self.get_logger().warning("/pd/lat handler received non-numeric payload: %s", vals)
+            return
+
+        clamped = self._clamp(value, LATERAL_INPUT_RANGE)
+        if not math.isclose(clamped, value, rel_tol=1e-6, abs_tol=1e-6):
+            self.get_logger().warn(
+                "Lateral input %.3f clipped to %.3f (range %.2f..%.2f)",
+                value,
+                clamped,
+                *LATERAL_INPUT_RANGE,
+            )
+
+        self._current_lateral = LATERAL_HOME_M + clamped * LATERAL_SCALE_M
+
+        if not self._wait_for_service(self.go_to, "GoTo"):
+            return
+
+        req = GoTo.Request()
+        if LATERAL_AXIS.lower() == "x":
+            self._set_position(req, axis="x", value=self._current_lateral)
+            self._set_position(req, axis="y", value=LATERAL_HOME_M)
+        else:
+            self._set_position(req, axis="y", value=self._current_lateral)
+            self._set_position(req, axis="x", value=LATERAL_HOME_M)
+        # Preserve altitude when issuing lateral moves so we do not dip.
+        self._set_position(req, axis="z", value=self._current_altitude)
+        self._assign_if_present(req, "duration", GO_TO_DURATION_S)
+        self._assign_if_present(req, "yaw", 0.0)
+        self._assign_if_present(req, "relative", RELATIVE_MOVES)
+        self._assign_if_present(req, "group_mask", GROUP_MASK)
+
+        self.get_logger().info(
+            "Commanding %s-axis slide to %.2fm (alt=%.2fm)",
+            LATERAL_AXIS,
+            self._current_lateral,
+            self._current_altitude,
+        )
+        self.go_to.call_async(req)
 
     def on_alt(self, addr, *vals):
-        self.get_logger().info("Received altitude input: %.3f", float(vals[0]))
-        # TODO: call self.takeoff / modify z targets.
+        value = self._extract_first_value(vals)
+        if value is None:
+            self.get_logger().warning("/pd/alt handler received non-numeric payload: %s", vals)
+            return
+
+        clamped = self._clamp(value, ALTITUDE_INPUT_RANGE)
+        if not math.isclose(clamped, value, rel_tol=1e-6, abs_tol=1e-6):
+            self.get_logger().warn(
+                "Altitude input %.3f clipped to %.3f (range %.2f..%.2f)",
+                value,
+                clamped,
+                *ALTITUDE_INPUT_RANGE,
+            )
+
+        height = ALTITUDE_FLOOR_M + clamped * ALTITUDE_SCALE_M
+        self._current_altitude = height
+
+        if not self._wait_for_service(self.takeoff, "Takeoff"):
+            return
+
+        req = Takeoff.Request()
+        applied = self._assign_if_present(req, "height", height)
+        if not applied:
+            # Fallback for alternative field naming (e.g. target.z).
+            self._set_position(req, axis="z", value=height)
+        self._assign_if_present(req, "duration", TAKEOFF_DURATION_S)
+        self._assign_if_present(req, "group_mask", GROUP_MASK)
+
+        self.get_logger().info("Commanding takeoff to %.2fm", height)
+        self.takeoff.call_async(req)
+
+    # ------------------------------------------------------------------
+    # Helper utilities
+    # ------------------------------------------------------------------
+
+    def _wait_for_service(self, client, label: str) -> bool:
+        if client.wait_for_service(timeout_sec=0.0):
+            return True
+        self.get_logger().warning("%s service not ready; dropping command", label)
+        return False
+
+    @staticmethod
+    def _extract_first_value(vals: Iterable[float]) -> Optional[float]:
+        if not vals:
+            return None
+        try:
+            return float(vals[0])
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _clamp(value: float, bounds: Iterable[float]) -> float:
+        lower, upper = bounds
+        return max(lower, min(upper, value))
+
+    def _set_position(self, req, *, axis: str, value: float) -> None:
+        candidates = ("goal", "position", "target")
+        axis = axis.lower()
+        for field in candidates:
+            if not hasattr(req, field):
+                continue
+            target = getattr(req, field)
+            if hasattr(target, axis):
+                setattr(target, axis, value)
+                return
+        self.get_logger().debug("Request missing %s axis field; left unchanged", axis)
+
+    @staticmethod
+    def _assign_if_present(msg, field: str, value) -> bool:
+        if hasattr(msg, field):
+            setattr(msg, field, value)
+            return True
+        return False
+
+    def destroy_node(self):  # type: ignore[override]
+        if hasattr(self, "server"):
+            try:
+                self.server.shutdown()
+                self.server.server_close()
+            except Exception:  # pragma: no cover - best effort cleanup
+                pass
+        super().destroy_node()
 
 
 def main():


### PR DESCRIPTION
## Summary
- translate `/pd/lat` and `/pd/alt` OSC values into CrazySwarm2 `GoTo` and `Takeoff` service requests with bounds checks and service availability handling
- expose tuning constants for service names, scaling, and timing so pilots can adapt the demo to their swarm geometry
- document prerequisites, launch steps, and safety notes for running the OSC-driven swarm demo

## Testing
- python -m compileall software/swarm/swarm_demo.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8951bbb0832585ff1990ca737070