### PR TITLE
Refresh reference links for MSP, safety, and inspiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Perceptual Drift — Audience‑Controlled FPV Installation
 
-Perceptual Drift is a participatory drone‑based installation where **audience motion** modulates **FPV drone** behavior and **live video processing**. It centers shared authorship: many bodies → probabilistic control → drones that “drift” perceptually. The installation leans on **DIY‑friendly stacks**: Betaflight micro‑drones, Raspberry Pi video processing (GStreamer/OBS), OpenFrameworks/Processing for gesture tracking, and an OSC→MSP control bridge. Optional **Teensy DSP/LED** layers extend visual/sonic feedback. Think of it as an unholy jam session between [Betaflight](https://betaflight.com/), [Processing](https://processing.org/), [GStreamer](https://gstreamer.freedesktop.org/), and [python-osc](https://pypi.org/project/python-osc/) with a splash of [Mozzi](https://sensorium.github.io/Mozzi/) and [CrazySwarm2](https://imrclab.github.io/crazyflie-clients-python/).
+Perceptual Drift is a participatory drone‑based installation where **audience motion** modulates **FPV drone** behavior and **live video processing**. It centers shared authorship: many bodies → probabilistic control → drones that “drift” perceptually. The installation leans on **DIY‑friendly stacks**: Betaflight micro‑drones, Raspberry Pi video processing (GStreamer/OBS), OpenFrameworks/Processing for gesture tracking, and an OSC→MSP control bridge. Optional **Teensy DSP/LED** layers extend visual/sonic feedback. Think of it as an unholy jam session between [Betaflight](https://betaflight.com/), [Processing](https://processing.org/), [GStreamer](https://gstreamer.freedesktop.org/), and [python-osc](https://pypi.org/project/python-osc/) with a splash of [Mozzi](https://sensorium.github.io/Mozzi/) and [CrazySwarm2](https://crazyswarm.readthedocs.io/).
 
 > **No breadcrumbs? No problem.** This README tries to be the missing field manual. Every subsystem below includes links, inspiration, and what to Google when things melt down.
 
@@ -31,9 +31,9 @@ Treat that order as gospel for newcomers: prototype, secure, rehearse, reflect, 
    - We ship normalized floats over OSC using [oscP5](https://www.sojamo.de/libraries/oscP5/) & [NetP5](https://www.sojamo.de/libraries/netP5/).
    - Inspirations: [OfxCv optical flow demos](https://github.com/kylemcdonald/ofxCv) and [LASER Tag (Graffiti Research Lab)](http://graffitiresearchlab.com/blog/projects/laser-tag/).
 2. **Control bridge (Pi/PC)** *(Python)*
-   - [`osc_msp_bridge.py`](software/control-bridge/osc_msp_bridge.py) converts the OSC data into Betaflight RC microseconds via the [Minimal Serial Protocol (MSP)](https://github.com/betaflight/betaflight/wiki/MSP). Think “software radio transmitter.”
+   - [`osc_msp_bridge.py`](software/control-bridge/osc_msp_bridge.py) converts the OSC data into Betaflight RC microseconds via the [Minimal Serial Protocol (MSP)](https://github.com/betaflight/betaflight.com/blob/master/docs/development/API/MSP-Extensions.md). Think “software radio transmitter.”
    - Uses [pyserial](https://pyserial.readthedocs.io/en/latest/), [python-osc](https://pypi.org/project/python-osc/), and config from `config/mapping.yaml`.
-   - Modelled after [DJI FPVgestures](https://github.com/whoisandrewd/fpv-gestures) and [Red Paper Heart’s drone installations](https://redpaperheart.com/).
+   - Modelled after [Tello gesture-flight experiments](https://github.com/kinivi/tello-gesture-control) and [Red Paper Heart’s drone installations](https://redpaperheart.com/).
 3. **FPV video pipeline** *(GStreamer / OBS)*
    - Analog FPV feed → VRX → USB capture card → [GStreamer](https://gstreamer.freedesktop.org/documentation/) pipeline or [OBS Studio](https://obsproject.com/) scenes.
    - Presets in [`software/video-pipeline/gst_launch.sh`](software/video-pipeline/gst_launch.sh) cover low-latency monitoring and delayed glitch feedback.
@@ -67,14 +67,14 @@ See `docs/diagrams/system-overview.md` for mermaid diagrams that stitch the abov
 1. **Hardware**
    - Net a 2×2 m cage. BetaFPV Cetus Pro or any 65–75 mm whoop running Betaflight 4.x works.
    - USB power a VRX + capture dongle (classic EasyCAP or UVC cards). Mount a short WS2812 strip (8–12 px) to the quad if you want glow feedback.
-   - Borrow ideas from [NOIR Drone Shows’ safety setups](https://noirdrones.com/) and [MIT’s FlyByWire cage](https://aerobotics.mit.edu/).
+   - Borrow ideas from [Intel’s drone show safety brief](https://www.intel.com/content/www/us/en/support/articles/000026520/drones.html) and [MIT’s Flyfire cage concept](https://senseable.mit.edu/flyfire/).
 2. **Tracking rig**
    - Install [Processing 4](https://processing.org/download) plus the `video`, `oscP5`, and `netP5` libraries.
    - Run `software/gesture-tracking/processing/PerceptualDrift_Tracker`. Aim any 720p-ish webcam at the audience area and tweak the `threshold` constant for your lighting.
 3. **Control bridge**
    - `pip install -r software/control-bridge/requirements.txt` (python-osc + pyserial + pyyaml).
    - Plug the drone’s flight controller in over USB, then run `python3 osc_msp_bridge.py --serial /dev/ttyUSB0`.
-   - Check out [Betaflight’s MSP docs](https://github.com/betaflight/betaflight/wiki/MSP) if you want to push extra AUX channels.
+   - Check out [Betaflight’s MSP docs](https://github.com/betaflight/betaflight.com/blob/master/docs/development/API/MSP-Extensions.md) if you want to push extra AUX channels.
 4. **Video pipeline**
    - `sudo apt install gstreamer1.0-tools` or use OBS.
    - Run `./software/video-pipeline/gst_launch.sh clean_low_latency` for tight monitoring or `delayed_glitch` for delayed projection loops. Adapted from [Scanlines’ GStreamer recipes](https://scanlines.xyz/t/gstreamer-recipes/1414).
@@ -94,18 +94,18 @@ See `docs/diagrams/system-overview.md` for mermaid diagrams that stitch the abov
 ---
 
 ## Ethics & Consent
-- Visible “consent gate”: drones/video remain idle until participants opt‑in (button/gesture). Inspired by [Studio Olafur Eliasson’s consent signage](https://olafureliasson.net/).
+- Visible “consent gate”: drones/video remain idle until participants opt‑in (button/gesture). Inspired by [Studio Olafur Eliasson’s participation consent practice](https://www.theartnewspaper.com/2019/07/09/olafur-eliasson-introduces-participation-consent-forms-to-new-tate-modern-show).
 - Data minimization: no face storage, no cloud calls. See `docs/PRIVACY_ETHICS.md` and `docs/ASSUMPTION_LEDGER.md` for what we log (spoiler: almost nothing).
-- Follow [ADA walkway clearance guidelines](https://www.access-board.gov/ada/) when placing cages and screens so wheelchairs aren’t boxed out.
+- Follow [ADA walkway clearance guidelines](https://www.access-board.gov/ada/chapter-4-accessible-routes/#403-walking-surfaces) when placing cages and screens so wheelchairs aren’t boxed out.
 
 ---
 
 ## Deep-dive links & inspo
 - **Control theory crash course**: [UAVTech’s Betaflight PID bible](https://www.uavtech.com/pids) for tuning feel vs. safety.
-- **Interactive art ancestors**: [Daniel Rozin’s mirror series](https://rozinmuseum.com/mirrors/) and [Rafael Lozano-Hemmer’s “Pulse”](https://www.lozano-hemmer.com/pulse_room.php) for crowd-controlled ambiance.
-- **Latency budgeting**: [Bitcraze’s article on Vicon + Crazyflie latency](https://www.bitcraze.io/2020/05/latency-in-position-control/) — relevant when you scale to swarms.
+- **Interactive art ancestors**: [Daniel Rozin’s mirror series](http://smoothware.com/danny/woodenmirror.html) and [Rafael Lozano-Hemmer’s “Pulse”](https://www.lozano-hemmer.com/pulse_room.php) for crowd-controlled ambiance.
+- **Latency budgeting**: [Bitcraze’s article on Vicon + Crazyflie latency](https://www.bitcraze.io/2020/05/latency-in-position-control-with-motion-capture/) — relevant when you scale to swarms.
 - **Network hygiene**: [NDI vs. SDI vs. analog FPV comparison](https://www.ptzoptics.com/guides/ndi/) if you swap video transports.
-- **Show control patterns**: [Ableton Link OSC bridges](https://github.com/ideoforms/ableton-link) and [TouchDesigner OSC out](https://docs.derivative.ca/OSC_Out_DAT) make for easy interoperability.
+- **Show control patterns**: [Ableton Link OSC bridges](https://github.com/ideoforms/link-python) and [TouchDesigner OSC out](https://docs.derivative.ca/OSC_Out_DAT) make for easy interoperability.
 
 ---
 

--- a/docs/control-stack-playbook.md
+++ b/docs/control-stack-playbook.md
@@ -32,7 +32,7 @@ Every stage is intentionally hackable: the architecture is a bunch of small scri
 ## OSC → MSP bridge
 
 - **Code**: [`software/control-bridge/osc_msp_bridge.py`](../software/control-bridge/osc_msp_bridge.py)
-- **Protocols**: [Open Sound Control 1.0](http://opensoundcontrol.org/spec-1_0) and Betaflight's [MSP 2.0](https://github.com/betaflight/betaflight/wiki/MSP-Protocol)
+- **Protocols**: [Open Sound Control 1.0](http://opensoundcontrol.org/spec-1_0) and Betaflight's [MSP 2.0](https://github.com/betaflight/betaflight.com/blob/master/docs/development/API/MSP-Extensions.md)
 - **Python helpers**: [`python-osc`](https://github.com/attwad/python-osc) for OSC, [`pySerial`](https://pyserial.readthedocs.io/en/latest/shortintro.html) for UART access.
 - **MSP refresher**: Each packet is `$M<` + payload length + command ID + bytes + XOR checksum. We're only using `MSP_SET_RAW_RC` (ID 200) and pushing eight 16-bit values (roll, pitch, throttle, yaw, AUX1–AUX4).
 - **Config**: [`config/mapping.yaml`](../config/mapping.yaml) holds every gain and OSC path. Change that file, not the code.

--- a/software/control-bridge/README.md
+++ b/software/control-bridge/README.md
@@ -6,11 +6,11 @@ you can rip it apart and wire in your own sensors, sequencers, or stage props.
 
 Keep these tabs open while you hack:
 
-* MSP spec crib sheet — https://github.com/betaflight/betaflight/wiki/MSP
+* MSP spec crib sheet — https://github.com/betaflight/betaflight.com/blob/master/docs/development/API/MSP-Extensions.md
 * python-osc API docs — https://pypi.org/project/python-osc/
 * Betaflight RC setup — https://github.com/betaflight/betaflight/wiki/RC-Setup
-* Inspiration: [DJI FPVgestures](https://github.com/whoisandrewd/fpv-gestures),
-  [MIT Swarm Lab](https://aerobotics.mit.edu/)
+* Inspiration: [Tello gesture-flight experiments](https://github.com/kinivi/tello-gesture-control),
+  [MIT’s Flyfire swarm sketches](https://senseable.mit.edu/flyfire/)
 
 ## Pipeline
 

--- a/software/control-bridge/osc_msp_bridge.py
+++ b/software/control-bridge/osc_msp_bridge.py
@@ -8,7 +8,7 @@ from your face.
 
 References worth opening in a browser tab while you read this file:
 
-* MSP command table — https://github.com/betaflight/betaflight/wiki/MSP
+* MSP command table — https://github.com/betaflight/betaflight.com/blob/master/docs/development/API/MSP-Extensions.md
 * python-osc docs — https://pypi.org/project/python-osc/
 * Betaflight raw RC ranges —
   https://github.com/betaflight/betaflight/wiki/RC-Setup

--- a/software/swarm/swarm_demo.py
+++ b/software/swarm/swarm_demo.py
@@ -9,7 +9,7 @@ This is not a complete swarm choreographer — it is a heavily commented startin
 point.  You will need a ROS 2 Foxy/Humble workspace with the crazyflie_ros2 stack
 installed.  Recommended reading:
 
-* CrazySwarm2 tutorial — https://imrclab.github.io/crazyswarm/usage/
+* CrazySwarm2 tutorial — https://crazyswarm.readthedocs.io/en/latest/usage.html
 * python-osc quickstart — https://pypi.org/project/python-osc/
 * ROS 2 services overview — https://docs.ros.org/en/humble/Concepts/Services.html
 """


### PR DESCRIPTION
## Summary
- point the MSP references at the maintained Betaflight documentation repo
- swap obsolete inspiration/safety links for current gesture, consent, and accessibility resources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd8f9b1ce883259e52e4d823158dbe